### PR TITLE
Allow multi-file module structures for non-cargo lints

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -23,7 +23,7 @@ class Rust(Linter):
     }
     cmd = ('rustc', '--no-trans')
     syntax = 'rust'
-    tempfile_suffix = 'rs'
+    tempfile_suffix = '-'
 
     regex = (
         r'^(?P<file>.+?):(?P<line>\d+):(?P<col>\d+):\s+\d+:\d+\s'


### PR DESCRIPTION
Using a tempfile does not work, because any file declaring a module will fail compilation when the module is not found in the temporary directory. Instead, invoke rustc directly on the source tree using `communicate` instead of `tmpfile`.
