### PR TITLE
Allow linting by invoking rustc on the crate root

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,8 @@ In addition to the standard SublimeLinter settings, SublimeLinter-contrib-rustc 
 |Setting|Description|
 |:------|:----------|
 |use-cargo|Use cargo to run rustc if a Cargo.toml is defined for your project (experimental)|
-
+|use-crate-root|Run rustc against the crate root to allow for multi-file module structures (experimental)|
+|crate-root|Override the filename of the crate root. Defaults are `main.rs` and `lib.rs` (experimental)|
 
 ## Contributing
 If you would like to contribute enhancements or fixes, please do the following:

--- a/linter.py
+++ b/linter.py
@@ -11,7 +11,7 @@
 """This module exports the Rustc plugin class."""
 
 import os
-from SublimeLinter.lint import Linter, util
+from SublimeLinter.lint import Linter, util, persist
 
 
 class Rust(Linter):
@@ -19,11 +19,13 @@ class Rust(Linter):
     """Provides an interface to Rust."""
 
     defaults = {
-        'use-cargo': False
+        'use-cargo': False,
+        'use-crate-root': False,
+        'crate-root': None,
     }
     cmd = ('rustc', '--no-trans')
     syntax = 'rust'
-    tempfile_suffix = '-'
+    tempfile_suffix = 'rs'
 
     regex = (
         r'^(?P<file>.+?):(?P<line>\d+):(?P<col>\d+):\s+\d+:\d+\s'
@@ -31,32 +33,139 @@ class Rust(Linter):
         r'(?P<message>.+)'
     )
 
-    def run(self, cmd, code):
-        """Return a list with the command to execute."""
-        use_cargo = self.get_view_settings().get('use-cargo', False)
+    use_cargo = False
+    use_crate_root = False
+    cargo_config = None
+    crate_root = None
 
-        if use_cargo:
-            config = util.find_file(
-                os.path.dirname(self.filename), 'Cargo.toml')
-            if config:
+    def run(self, cmd, code):
+        """
+        Return a list with the command to execute.
+
+        The command chosen is resolved as follows:
+
+        If the `use-cargo` option is set, lint using a `cargo build`.
+        If cargo is not used, and the `use-crate-root` option is set, lint
+        the crate root. Finally, if the crate root cannot be determined, or the
+        `use-crate-root` option is not set, lint the current file.
+
+        Linting the crate (either through cargo or rustc) means that if
+        errors are caught in other files, errors on the current file might
+        not show up until these other errors are resolved.
+
+        Linting a single file means that any imports from higher in the
+        module hierarchy will probably cause an error and prevent proper
+        linting in the rest of the file.
+        """
+        self.use_cargo = self.get_view_settings().get('use-cargo', False)
+        self.use_crate_root = self.get_view_settings().get('use-crate-root', False)
+
+        if self.use_cargo:
+            current_dir = os.path.dirname(self.filename)
+            self.cargo_config = util.find_file(current_dir, 'Cargo.toml')
+
+            if self.cargo_config:
+                self.tempfile_suffix = '-'
+
                 return util.communicate(
-                    ['cargo', 'build', '--manifest-path', config],
-                    None,
+                    ['cargo', 'build', '--manifest-path', self.cargo_config],
+                    code=None,
                     output_stream=self.error_stream,
                     env=self.env)
 
-        # Lint the file in-place to allow for module structure across files
-        return self.communicate(cmd, None)
+        if self.use_crate_root:
+            self.crate_root = self.locate_crate_root()
+
+            if self.crate_root:
+                cmd.append(self.crate_root)
+                self.tempfile_suffix = '-'
+
+                return util.communicate(
+                    cmd,
+                    code=None,
+                    output_stream=self.error_stream,
+                    env=self.env)
+
+        self.tempfile_suffix = 'rs'
+        return self.tmpfile(cmd, code)
 
     def split_match(self, match):
         """
         Return the components of the match.
 
         We override this because Cargo lints all referenced files,
-        and we only want errors from the linted file.
+        and we only want errors from the linted file. The same applies
+        when linting from the crate root. Of course when linting a single
+        file only, all the errors will be from that file because it is
+        in a temporary directory.
+
+        The matched file path is considered in the context of a working directory.
+        If it is an absolute path, the working directory will be ignored. This
+        working directory is not the same as the current Sublime Text process
+        working directory -- it is the working directory of an external command.
+
+        For Cargo, the working directory is the directory of Cargo.toml.
+        When working with a crate root, the working directory is the directory of the
+        crate root source file.
         """
-        if match:
-            if os.path.basename(self.filename) != os.path.basename(match.group('file')):
-                match = None
+        matched_file = match.group('file') if match else None
+
+        if matched_file:
+            if self.use_cargo:
+                working_dir = os.path.dirname(self.cargo_config)
+
+                if not self.is_current_file(working_dir, matched_file):
+                    match = None
+
+            elif self.use_crate_root:
+                working_dir = os.path.dirname(self.crate_root)
+
+                if not self.is_current_file(working_dir, matched_file):
+                    match = None
 
         return super().split_match(match)
+
+    def is_current_file(self, working_dir, matched_file):
+        """
+        Return true if `matched_file` is logically the same file as `self.filename`.
+
+        Cargo example demonstrating how matching is done:
+
+          - os.getcwd() = '/Applications/Sublime Text.app/Contents/MacOS'
+          - `working_dir` = '/path/to/project'
+          - `matched_file` = 'src/foo.rs'
+          - `self.filename` = '/path/to/project/src/foo.rs'
+
+        The current OS directory is not considered at all -- comparison is only done
+        relative to where Cargo.toml was found.  `os.path.realpath` is used to
+        normalize the filenames so that they can be directly compared after manipulation.
+        """
+        abs_matched_file = os.path.join(working_dir, matched_file)
+
+        persist.debug('Sublime Text cwd: ', os.getcwd())
+        persist.debug('Build cwd: ', working_dir)
+        persist.debug('Current filename: ', self.filename)
+        persist.debug('Matched filename: ', matched_file)
+        persist.debug('Compared filename: ', abs_matched_file)
+
+        return os.path.realpath(self.filename) == os.path.realpath(abs_matched_file)
+
+    def locate_crate_root(self):
+        """
+        Return the filename of the crate root.
+
+        The filename may be manually set in a configuration file (highest priority),
+        or it is located by convention.
+
+        When no configuration is set, main.rs will take preference over lib.rs.
+        If neither main.rs or lib.rs are found, give up.
+        """
+        crate_root = self.get_view_settings().get('crate-root', None)
+
+        if not crate_root:
+            crate_root = util.find_file(os.path.dirname(self.filename), 'main.rs')
+
+        if not crate_root:
+            crate_root = util.find_file(os.path.dirname(self.filename), 'lib.rs')
+
+        return crate_root


### PR DESCRIPTION
When not using cargo, this allows the linting of files in the module hierarchy that do not compile in isolation.
For example, invoking rustc on a module that `use`s something with an absolute path from the crate root, will fail.
Instead of invoking rustc on a single file, we do so on the crate root so that all imports are resolved and then
filter the errors in the current file (same as when using Cargo.toml).

This behavior can be enabled by using the `use-crate-root` option. By default, the crate root is considered to be
`main.rs` or `lib.rs`. This can be overridden by using the `crate-root` option. If no crate root is found, the
current file is linted instead.
