### PR TITLE
Use correct command-line options to rustc

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -23,7 +23,7 @@ class Rust(Linter):
         'use-crate-root': False,
         'crate-root': None,
     }
-    cmd = ('rustc', '--no-trans')
+    cmd = ('rustc', '-Z no-trans')
     syntax = 'rust'
     tempfile_suffix = 'rs'
 


### PR DESCRIPTION
fixes issue: https://github.com/oschwald/SublimeLinter-contrib-
rustc/issues/9