### PR TITLE
Use correct cmd list syntax

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -23,7 +23,7 @@ class Rust(Linter):
         'use-crate-root': False,
         'crate-root': None,
     }
-    cmd = ('rustc', '-Z no-trans')
+    cmd = ('rustc', '-Z', 'no-trans')
     syntax = 'rust'
     tempfile_suffix = 'rs'
 


### PR DESCRIPTION
I made an error in the syntax for cmd last time. Tested this and it works properly now.