### PR TITLE
Updated regex for new error format

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -22,14 +22,16 @@ class Rust(Linter):
         'use-crate-root': False,
         'crate-root': None,
     }
-    cmd = ['rustc', '-Zno-trans']
+    cmd = ['rustc']
     syntax = 'rust'
     tempfile_suffix = 'rs'
 
-    regex = (r'^(?P<file>.+?):(?P<line>\d+):(?P<col>\d+):\s+\d+:\d+\s'
-             r'(?:(?P<error>(error|fatal error))|(?P<warning>warning)):\s+'
-             r'(?P<message>.+)')
+    regex = r'''(?xi)
+            ^(?:(?P<error>(error|fatal error))|(?P<warning>warning)).*?:\s+(?P<message>.+)\s*\r?
+            -->\s+(?P<file>.+?):(?P<line>\d+):(?P<col>\d+)$
+            '''
 
+    multiline = True
     use_cargo = False
     use_cargo_check = False
     use_crate_root = False


### PR DESCRIPTION
The error format changed tremendously between 1.11 and 1.12. I created a new regular expression that works with the new error format for both standalone rs files and Cargo projects. At first, I was stumped on how to handle the whitespace between error message lines, but then I found that SublimeLinter has a method of handling these cases: http://www.sublimelinter.com/en/latest/linter_attributes.html#re-flags-example

This should fix #26. 