### PR TITLE
Add support for Rust Enhanced syntax 

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -23,7 +23,7 @@ class Rust(Linter):
         'crate-root': None,
     }
     cmd = ['rustc']
-    syntax = 'rust'
+    syntax = ('rust', 'rustenhanced')
     tempfile_suffix = 'rs'
 
     regex = r'''(?xi)


### PR DESCRIPTION
If you install the plugin Rust Enhanced (https://github.com/rust-lang/sublime-rust), it changes the syntax of rust files to Rust Enhanced (as opposed to Rust). With this minor change the linter will also lint files with the rust-enhanced syntax, so you can benefit from both plugins.