### PR TITLE
Rewrite for SL4

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,62 +3,77 @@ SublimeLinter-contrib-rustc
 
 [![Build Status](https://travis-ci.org/oschwald/SublimeLinter-contrib-rustc.svg?branch=master)](https://travis-ci.org/oschwald/SublimeLinter-contrib-rustc)
 
-This linter plugin for [SublimeLinter][docs] provides an interface to [rustc](http://www.rust-lang.org/). It will be used with files that have the "rust" syntax.
+This linter plugin for [SublimeLinter][docs]
+provides an interface to [rustc and cargo](http://www.rust-lang.org/).
+It will be used with files using the Rust syntax.
+
+By default, `cargo` will be run for saved files only,
+assuming your project defines a `Cargo.toml` file in its root.
+`rustc` is available as a fallback
+and may also be used to lint files in background mode, if desired.
+See the [settings](#settings) for more.
 
 ## Installation
-SublimeLinter 3 must be installed in order to use this plugin. If SublimeLinter 3 is not installed, please follow the instructions [here][installation].
+SublimeLinter must be installed in order to use this plugin.
+If SublimeLinter is not installed,
+please follow the instructions [here][installation].
 
 ### Linter installation
-Before using this plugin, you must ensure that `rustc` is installed on your system. To install `rustc`, install Rust as directed in the [Rust tutorial](https://static.rust-lang.org/doc/master/book/getting-started.html).
+Before using this plugin,
+you must ensure that `rustc` and `cargo` are installed on your system.
+To install `rustc`,
+install Rust as directed in the [Rust tutorial](https://static.rust-lang.org/doc/master/book/getting-started.html).
 
 ### Linter configuration
-In order for `rustc` to be executed by SublimeLinter, you must ensure that its path is available to SublimeLinter. Before going any further, please read and follow the steps in ["Finding a linter executable"](http://sublimelinter.readthedocs.org/en/latest/troubleshooting.html#finding-a-linter-executable) through “Validating your PATH” in the documentation.
+In order for `rustc` and `cargo` to be executed by SublimeLinter,
+you must ensure that its path is available to SublimeLinter.
+Before going any further,
+please read and follow the steps in ["Finding a linter executable"](http://sublimelinter.readthedocs.org/en/latest/troubleshooting.html#finding-a-linter-executable)
+through “Validating your PATH” in the documentation.
 
 Once you have installed and configured `rustc`, you can proceed to install the SublimeLinter-contrib-rustc plugin if it is not yet installed.
 
 ### Plugin installation
-Please use [Package Control][pc] to install the linter plugin. This will ensure that the plugin will be updated when new versions are available. If you want to install from source so you can modify the source code, you probably know what you are doing so we won’t cover that here.
+Please use [Package Control][pc] to install the linter plugin.
+This will ensure that the plugin will be updated
+when new versions are available.
+If you want to install from source so you can modify the source code,
+you probably know what you are doing.
 
 To install via Package Control, do the following:
 
-1. Within Sublime Text, bring up the [Command Palette][cmd] and type `install`. Among the commands you should see `Package Control: Install Package`. If that command is not highlighted, use the keyboard or mouse to select it. There will be a pause of a few seconds while Package Control fetches the list of available plugins.
+1. Within Sublime Text, bring up the [Command Palette][cmd] and type `install`.
+Among the commands you should see `Package Control: Install Package`.
+If that command is not highlighted,
+use the keyboard or mouse to select it.
+There will be a pause of a few seconds
+while Package Control fetches the list of available plugins.
 
-1. When the plugin list appears, type `rustc`. Among the entries you should see `SublimeLinter-contrib-rustc`. If that entry is not highlighted, use the keyboard or mouse to select it.
+1. When the plugin list appears, type `rustc`.
+Among the entries you should see `SublimeLinter-contrib-rustc`.
+If that entry is not highlighted,
+use the keyboard or mouse to select it.
 
 ## Settings
-For general information on how SublimeLinter works with settings, please see [Settings][settings]. For information on generic linter settings, please see [Linter Settings][linter-settings].
+For general information on how SublimeLinter works with settings,
+please see [Settings][settings].
+For information on generic linter settings,
+please see [Linter Settings][linter-settings].
 
-In addition to the standard SublimeLinter settings, SublimeLinter-contrib-rustc provides its own settings.
+In addition to the standard SublimeLinter settings,
+SublimeLinter-contrib-rustc provides its own settings.
 
 |Setting|Description|
 |:------|:----------|
-|use-cargo|Use `cargo` to run rustc if a Cargo.toml is defined for your project.|
-|use-cargo-check|Use `cargo check` to validate. Requires `cargo-check` and a Cargo.toml for your project.|
-|use-crate-root|Run rustc against the crate root to allow for multi-file module structures|
-|crate-root|Override the filename of the crate root. Defaults are `main.rs` and `lib.rs`|
+|`cargo_command`|The command to run with cargo. Examples: `check all`, `test all`, `clippy` or `build`. Default: `"check"`|
+|`rustc_live`|Since `cargo` only operates on entire projects, you may elect to run `rustc` on the current file only. This can quickly fail because of imports, however. Default: `false`|
+|`rustc_fallback`|When a `Cargo.toml` file cannot be found, use just `rustc` as a fallback. This allows linting stand-alone files. Default: `true`|
 
-## Contributing
-If you would like to contribute enhancements or fixes, please do the following:
-
-1. Fork the plugin repository.
-2. Hack on a separate topic branch created from the latest `master`.
-3. Commit and push the topic branch.
-4. Make a pull request.
-5. Be patient.  ;-)
-
-Please note that modification should follow these coding guidelines:
-
-- Indent is 4 spaces.
-- Code should pass flake8 and pep257 linters.
-- Vertical whitespace helps readability, don't be afraid to use it.
-- Please use descriptive variable names, no abbreviations unless they are very well known.
-
-Thank you for helping out!
 
 [docs]: http://sublimelinter.readthedocs.org
 [installation]: http://sublimelinter.readthedocs.org/en/latest/installation.html
 [locating-executables]: http://sublimelinter.readthedocs.org/en/latest/usage.html#how-linter-executables-are-located
-[pc]: https://sublime.wbond.net/installation
+[pc]: https://packagecontrol.io/installation
 [cmd]: http://docs.sublimetext.info/en/sublime-text-3/extensibility/command_palette.html
 [settings]: http://sublimelinter.readthedocs.org/en/latest/settings.html
 [linter-settings]: http://sublimelinter.readthedocs.org/en/latest/linter_settings.html


### PR DESCRIPTION
Conform to SL4 changes, using better integration and a couple bugfixes. Also uses rustc's JSON error format.

All old settings have been removed and replaced by new ones.

I mean, it is pretty much a complete rewrite.

If you're not looking forward to maintaining the package anymore, I can do so. I maintain two other linter plugins already and followed the SL4 rewrite, allowing me to know where to make changes.
If you agree, I would move the fork over to my main account and replace the entry in Package Control's default channel. Or you can transfer the repo over, if you like.

Fixes #33, fixes #25, fixes #24 (by using SL4's `working_dir` setting), fixes #21 (through the custom command setting), fixes #5
Related: #26.

Probably needs some further testing as I'm sure I haven't run into all the corner cases with my very simple test setup.